### PR TITLE
Added function in BwaMem to allow for tunning scoring parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/main/java/com/github/lindenb/jbwa/ws/server/jaxws
 *.pac
 *.sa
 bwa-*
+test/ExampleSEChangeMemOptTestOutput.txt

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,16 @@ JAVAH ?= javah
 CFLAGS=-O3 -Wall  -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 BWAJNIQUALPACKAGE=com.github.lindenb.jbwa.jni
 JAVASRCDIR=src/main/java
-JAVACLASSNAME= Example Example2 BwaIndex BwaMem KSeq ShortRead AlnRgn BwaFrame
+JAVACLASSNAME= Example Example2 ExampleSEChangeMemOpt BwaIndex BwaMem KSeq ShortRead AlnRgn BwaFrame
 JAVACLASSSRC=$(addprefix src/main/java/com/github/lindenb/jbwa/jni/,$(addsuffix .java,$(JAVACLASSNAME)))
 JAVAQUALNAME=$(addprefix ${BWAJNIQUALPACKAGE}.,$(JAVACLASSNAME))
 JAR=jbwa.jar
 NATIVETARFILE=jbwa-native.tar
 BWAOBJS= utils.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o kthread.o bwamem_extra.o
-REF=test/ref.fa
-FASTQ1=test/R1.fq
-FASTQ2=test/R2.fq
+TESTDIR=test
+REF=${TESTDIR}/ref.fa
+FASTQ1=${TESTDIR}/R1.fq
+FASTQ2=${TESTDIR}/R2.fq
 FASTQ=${FASTQ1}
 OSNAME=$(shell uname)
 
@@ -52,9 +53,9 @@ REF?=human_g1k_v37.fasta
 FASTQ?=file.fastq.gz
 
 CC?=gcc
-.PHONY:all compile jar tar test.cmdline.simple test.cmdline.double test.gui test.ws test .ws.client test.ws.server clean
+.PHONY:all compile jar tar test.cmdline.simple test.cmdline.double test.cmdline.simpleOpt test.gui test.ws test .ws.client test.ws.server clean
 
-all:test.cmdline.double jar tar
+all: test.cmdline.double test.cmdline.simpleOpt jar tar
 
 test.ws: test.ws.server
 
@@ -77,6 +78,10 @@ test.cmdline.simple :${native.dir}/libbwajni.${native.extension} ${REF}.bwt
 	(gunzip -c $(FASTQ) | cat ${FASTQ}) | java  -Djava.library.path=${native.dir} -cp ${JAVASRCDIR} ${BWAJNIQUALPACKAGE}.Example $(REF) -| tail 
 	echo "TEST BWA/NATIVE:"
 	(gunzip -c $(FASTQ) | cat ${FASTQ})| bwa-${BWA.version}/bwamem-lite ${REF} -  | tail 
+
+test.cmdline.simpleOpt :${native.dir}/libbwajni.${native.extension} ${REF}.bwt
+	echo "TEST BWA/JNI modify mem_opt:"
+	(gunzip -c $(FASTQ) | cat ${FASTQ}) | java  -Djava.library.path=${native.dir} -cp ${JAVASRCDIR} ${BWAJNIQUALPACKAGE}.ExampleSEChangeMemOpt $(REF) - > ${TESTDIR}/ExampleSEChangeMemOptTestOutput.txt
 
 test.cmdline.double :${native.dir}/libbwajni.${native.extension} ${REF}.bwt
 	echo "TEST BWA/JNI:"

--- a/src/main/native/bwajni.c
+++ b/src/main/native/bwajni.c
@@ -290,6 +290,23 @@ JNIEXPORT jlong JNICALL QUALIFIEDMETHOD(BwaMem_mem_1opt_1init)(JNIEnv *env, jcla
 	return (jlong)mem_opt_init();
 	}
 
+/** BWAMem : update part of mem_opt scoring parameters  */
+JNIEXPORT void JNICALL QUALIFIEDMETHOD(BwaMem_update_1score_1parameters)(JNIEnv *env, jobject self, 
+                                                                         jint B, 
+                                                                         jint Oi, jint Od, 
+                                                                         jint Ei, jint Ed, 
+                                                                         jint L5, jint L3)
+  {
+  mem_opt_t* opt= _getBwaMem(env,self);
+  opt->b = (int) B;
+  opt->o_del = (int) Oi;
+  opt->o_ins = (int) Od;
+  opt->e_del = (int) Ei;
+  opt->e_ins = (int) Ed;
+  opt->pen_clip5 = (int) L5;
+  opt->pen_clip3 = (int) L3;
+  }
+
 /** BWAMem dispose the resource. A simple call to free() */
 JNIEXPORT void JNICALL QUALIFIEDMETHOD(BwaMem_dispose)(JNIEnv* env, jobject self)
 	{


### PR DESCRIPTION
Hi Pierre,

I've added a functionality to this project so that one may update the scoring parameters used in `bwa mem` at will.

The particular parameters affected are

```
Scoring options:

       -B INT        penalty for a mismatch [4]
       -O INT[,INT]  gap open penalties for deletions and insertions [6,6]
       -E INT[,INT]  gap extension penalty; a gap of size k cost '{-O} + {-E}*k' [1,1]
       -L INT[,INT]  penalty for 5'- and 3'-end clipping [5,5]
```

To test that it actually works and produces the same result as ones produced by `bwamem-lite`, you can refer to steps mentioned [here](https://github.com/broadinstitute/gatk/issues/1942).

Thank you very much!

Steve
