### PR TITLE
set verbosity

### DIFF
--- a/src/main/java/com/github/lindenb/jbwa/jni/BwaMem.java
+++ b/src/main/java/com/github/lindenb/jbwa/jni/BwaMem.java
@@ -263,6 +263,18 @@ public class BwaMem
 	public native void dispose();
 	
   private static native long mem_opt_init();
+
+	/**
+	 * Verbosity (from http://bio-bwa.sourceforge.net/bwa.shtml#3)
+	 * A value 0 for disabling all the output to stderr;
+	 * 1 for outputting errors only;
+	 * 2 for warnings and errors;
+	 * 3 for all normal messages;
+	 * 4 or higher for debugging. When this option takes value 4, the output is not SAM.
+	 *
+	 * If this method is not called, the default level is 3.
+	*/
+	public native void set_verbosity(int verbosity);
 	private native void update_score_parameters(int B, int Oi, int Od, int Ei, int Ed, int L5, int L3);
 	private native AlnRgn[] align(BwaIndex bwaIndex,byte bases[])  throws IOException;
 	private native String[] align2(BwaIndex bwaIndex,final ShortRead ks1[],final ShortRead ks2[])  throws IOException;

--- a/src/main/java/com/github/lindenb/jbwa/jni/Example2.java
+++ b/src/main/java/com/github/lindenb/jbwa/jni/Example2.java
@@ -214,14 +214,17 @@ public class Example2
 	public static void main(String args[]) throws IOException
 		{
 		System.loadLibrary("bwajni");
-		if(args.length!=3)
+		if(args.length < 3 || (args.length >= 4 && !"-v".equals(args[3])))
 			{
-			System.out.println("Usage [ref.fa] fastq1 fasta2\n");
+			System.out.println("Usage ref.fa fastq1 fasta2 [-v]\n");
 			return;
 			}
 
 		BwaIndex index=new BwaIndex(new File(args[0]));
 		BwaMem mem=new BwaMem(index);
+			if (args.length == 4) {
+				mem.set_verbosity(4);
+			}
 		KSeq kseq1=new KSeq(new File(args[1]));
 		KSeq kseq2=new KSeq(new File(args[2]));
 	

--- a/src/main/native/bwajni.c
+++ b/src/main/native/bwajni.c
@@ -207,6 +207,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "bwamem.h"
+#include "bwa.h"
 #include "kseq.h" // for the FASTA/Q parser
 #include "bwajni.h"
 KSEQ_DECLARE(gzFile)
@@ -283,6 +284,12 @@ JNIEXPORT jlong JNICALL QUALIFIEDMETHOD(BwaIndex__1open)(JNIEnv *env, jclass c, 
 /***************************************************************************************************/
 
 CAST_REF_OBJECT(mem_opt_t*,BwaMem,"ref")
+
+JNIEXPORT void JNICALL QUALIFIEDMETHOD(BwaMem_set_1verbosity)(JNIEnv *env, jobject self, 
+                                                                         jint verbosity)
+{
+  bwa_verbose = verbosity;
+}
 
 /** BWAMem : a simple call to ::mem_opt_init  */
 JNIEXPORT jlong JNICALL QUALIFIEDMETHOD(BwaMem_mem_1opt_1init)(JNIEnv *env, jclass c)


### PR DESCRIPTION
addresses the problem of high verbosity https://github.com/broadinstitute/gatk/issues/2054
by providing a setter for `bwa_verbose`

To test it, I added a parameter -v to Example2.

```
non verbose:
java -Djava.library.path=src/main/native  -cp src/main/java com.github.lindenb.jbwa.jni.Example2 test/ref.fa ./test/R1.fq ./test/R2.fq
```

```
verbose
java -Djava.library.path=src/main/native  -cp src/main/java com.github.lindenb.jbwa.jni.Example2 test/ref.fa ./test/R1.fq ./test/R2.fq -v
```
