### PR TITLE
Fix off by one error in SE alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ FASTQ?=file.fastq.gz
 CC?=gcc
 .PHONY:all compile jar tar test.cmdline.simple test.cmdline.double test.cmdline.simpleOpt test.gui test.ws test .ws.client test.ws.server clean
 
-all: test.cmdline.double test.cmdline.simpleOpt jar tar
+all: jar tar test.cmdline.simple test.cmdline.double test.cmdline.simpleOpt
 
 test.ws: test.ws.server
 
@@ -75,9 +75,9 @@ test.ws.client:
 
 test.cmdline.simple :${native.dir}/libbwajni.${native.extension} ${REF}.bwt
 	echo "TEST BWA/JNI:"
-	(gunzip -c $(FASTQ) | cat ${FASTQ}) | java  -Djava.library.path=${native.dir} -cp ${JAVASRCDIR} ${BWAJNIQUALPACKAGE}.Example $(REF) -| tail 
+	java  -Djava.library.path=${native.dir} -cp ${JAVASRCDIR} ${BWAJNIQUALPACKAGE}.Example $(REF) $(FASTQ) | tail 
 	echo "TEST BWA/NATIVE:"
-	(gunzip -c $(FASTQ) | cat ${FASTQ})| bwa-${BWA.version}/bwamem-lite ${REF} -  | tail 
+	bwa-${BWA.version}/bwamem-lite ${REF} $FASTQ | tail 
 
 test.cmdline.simpleOpt :${native.dir}/libbwajni.${native.extension} ${REF}.bwt
 	echo "TEST BWA/JNI modify mem_opt:"

--- a/src/main/native/bwajni.c
+++ b/src/main/native/bwajni.c
@@ -371,7 +371,7 @@ JNIEXPORT jobjectArray JNICALL QUALIFIEDMETHOD(BwaMem_align)(JNIEnv *env, jobjec
 		
 		VERIFY_NOT_NULL(alnRgn = (*env)->NewObject(env, alnClass, constructor, 
 			 (*env)->NewStringUTF(env, idx->bns->anns[a.rid].name),
-			 (jlong)a.pos,
+			 (jlong)(a.pos+1),
 			 (jbyte)"+-"[a.is_rev],
 			 (*env)->NewStringUTF(env, cigarStr),
 			 (jint)a.mapq,


### PR DESCRIPTION
Currently, the native code in this binding that performs alignment for SE reads is simulating bwa's code in `example.c`.
Unfortunately, the output mapping position by `example.c` (or `mem_aln_t` returned by `mem_reg2aln()`) is off by one. This could be verified by running the `bwamem-lite` program (which is the example.c code) on any FASTQ and compare with production `bwa mem`.

The cause for this discrepancy is unknown exactly, but one can get a hint by looking at the `mem_aln2sam()` function defined in `bwamem.c` where sam string is computed from an input `mem_aln_t` object/struct.
In particular, lines 836, 854 are adding one to the `pos` member of the input `mem_aln_t` for use in the output sam string.

This fix is the minimal effort (1 line only) to fix this problem.
