### PR TITLE
Adding AS Tag to Single End reads

### DIFF
--- a/src/main/java/com/github/lindenb/jbwa/jni/AlnRgn.java
+++ b/src/main/java/com/github/lindenb/jbwa/jni/AlnRgn.java
@@ -215,8 +215,9 @@ public class AlnRgn
 	private String cigar;
 	private int mqual;
 	private int NM;
+	private int AS;
 	private int secondary;
-	public AlnRgn(String chrom,long pos,byte strand,String cigar,int mqual,int NM,int secondary)
+	public AlnRgn(String chrom,long pos,byte strand,String cigar,int mqual,int NM,int AS, int secondary)
 		{
 		this.chrom=chrom;
 		this.pos=pos;
@@ -224,6 +225,7 @@ public class AlnRgn
 		this.cigar=cigar;
 		this.mqual=mqual;
 		this.NM=NM;
+		this.AS=AS;
 		this.secondary=secondary;
 		}
 	
@@ -233,11 +235,12 @@ public class AlnRgn
 	public String getCigar() { return this.cigar;}	
 	public int getMQual() { return this.mqual;}	
 	public int getNm() { return this.NM;}	
+	public int getAs() { return this.AS;}
 	public int getSecondary() { return this.secondary;}
 	
 	@Override
 	public String toString()
 		{
-		return ""+chrom+":"+String.valueOf(pos)+"("+(char)this.strand+");"+cigar+";"+mqual+";"+NM+";"+getSecondary();
+		return ""+chrom+":"+String.valueOf(pos)+"("+(char)this.strand+");"+cigar+";"+mqual+";"+NM+";"+AS+";"+getSecondary();
 		}
 	}

--- a/src/main/java/com/github/lindenb/jbwa/jni/Example.java
+++ b/src/main/java/com/github/lindenb/jbwa/jni/Example.java
@@ -236,6 +236,7 @@ public class Example
 					a.getPos()+"\t"+
 					a.getMQual()+"\t"+
 					a.getCigar()+"\t"+
+					a.getAs() +"\t"+
 					a.getNm()
 					);
 				}

--- a/src/main/native/bwajni.c
+++ b/src/main/native/bwajni.c
@@ -376,7 +376,7 @@ JNIEXPORT jobjectArray JNICALL QUALIFIEDMETHOD(BwaMem_align)(JNIEnv *env, jobjec
 			 (*env)->NewStringUTF(env, cigarStr),
 			 (jint)a.mapq,
 			 a.NM,
-			 ar.a[i].score,
+			 ar.a[i].truesc,
 			 ar.a[i].secondary
 			 ));
 

--- a/src/main/native/bwajni.c
+++ b/src/main/native/bwajni.c
@@ -339,7 +339,7 @@ JNIEXPORT jobjectArray JNICALL QUALIFIEDMETHOD(BwaMem_align)(JNIEnv *env, jobjec
   	
   	
   	VERIFY_NOT_NULL(alnClass = (*env)->FindClass(env, PACKAGEPATH "AlnRgn"));
-	VERIFY_NOT_NULL(constructor = (*env)->GetMethodID(env,alnClass,"<init>", "(Ljava/lang/String;JBLjava/lang/String;III)V"));
+	VERIFY_NOT_NULL(constructor = (*env)->GetMethodID(env,alnClass,"<init>", "(Ljava/lang/String;JBLjava/lang/String;IIII)V"));
   	VERIFY_NOT_NULL(returnedArray = (*env)->NewObjectArray(env,ar.n, alnClass, 0));
 	
 	// get all the hits
@@ -376,6 +376,7 @@ JNIEXPORT jobjectArray JNICALL QUALIFIEDMETHOD(BwaMem_align)(JNIEnv *env, jobjec
 			 (*env)->NewStringUTF(env, cigarStr),
 			 (jint)a.mapq,
 			 a.NM,
+			 ar.a[i].score,
 			 ar.a[i].secondary
 			 ));
 


### PR DESCRIPTION
this would resolve #14. 
I currently use ar.a[i].truesc (and not ar.a[i].score), maybe this can be double checked.
see https://github.com/lh3/bwa/blob/master/bwamem.h